### PR TITLE
Improve composer constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,24 +2,21 @@
     "name": "fabpot/silex-skeleton",
     "require": {
         "php": ">=5.3.3",
-        "silex/silex": "1.0.*",
-        "twig/twig": ">=1.8.0,<2.0-dev",
-        "monolog/monolog": ">=1.0.0,<1.2-dev",
-        "symfony/browser-kit": "2.1.*",
-        "symfony/class-loader": "2.1.*",
-        "symfony/config": "2.1.*",
-        "symfony/console": "2.1.*",
-        "symfony/css-selector": "2.1.*",
-        "symfony/finder": "2.1.*",
-        "symfony/form": "2.1.*",
-        "symfony/monolog-bridge": "2.1.*",
-        "symfony/process": "2.1.*",
-        "symfony/security": "2.1.*",
-        "symfony/translation": "2.1.*",
-        "symfony/twig-bridge": "2.1.*",
-        "symfony/validator": "2.1.*"
+        "silex/silex": "1.0.*@dev",
+        "symfony/browser-kit": "~2.1",
+        "symfony/class-loader": "~2.1",
+        "symfony/config": "~2.1",
+        "symfony/console": "~2.1",
+        "symfony/css-selector": "~2.1",
+        "symfony/finder": "~2.1",
+        "symfony/form": "~2.1",
+        "symfony/monolog-bridge": "~2.1",
+        "symfony/process": "~2.1",
+        "symfony/security": "~2.1",
+        "symfony/translation": "~2.1",
+        "symfony/twig-bridge": "~2.1",
+        "symfony/validator": "~2.1"
     },
-    "minimum-stability": "dev",
     "autoload": {
         "psr-0": { "": "src/" }
     }


### PR DESCRIPTION
- Change symfony/\* from 2.1.\* to ~2.1, so that users get 2.2 once stable
- Delegate twig and monolog versions to bridges, so users get the
  correct version of twig once 2.2 becomes stable.
- Remove minimum-stability=dev, so that users get stable versions.
