### PR TITLE
composer.phar ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /vendor/
 composer.lock
-
+composer.phar


### PR DESCRIPTION
I think composer.phar file should be ignored as well.
