### PR TITLE
Use more future proof version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "type": "project",
     "require": {
         "php": ">=5.3.3",
-        "silex/silex": "2.0.x-dev",
-        "silex/web-profiler": "2.0.x-dev",
+        "silex/silex": "~2.0@dev",
+        "silex/web-profiler": "~2.0@dev",
         "symfony/browser-kit": "~2.3",
         "symfony/class-loader": "~2.3",
         "symfony/config": "~2.3",


### PR DESCRIPTION
That way users can just remove the `@dev` when silex stable comes out, and if they don't at least they'll upgrade to 2.1.x-dev etc instead of being stuck on the 2.0-dev forever.
