### PR TITLE
fix $app->error() number of callback arguments

### DIFF
--- a/src/controllers.php
+++ b/src/controllers.php
@@ -14,7 +14,7 @@ $app->get('/', function () use ($app) {
 ->bind('homepage')
 ;
 
-$app->error(function (\Exception $e, $code) use ($app) {
+$app->error(function (\Exception $e, Request $request, $code) use ($app) {
     if ($app['debug']) {
         return;
     }


### PR DESCRIPTION
Silex\Application::error($callback) - $callback accepts 3 arguments: \Exception $e, Request $request, $code