### PR TITLE
[Asset] Check whether the asset starts with a slash or not

### DIFF
--- a/src/app.php
+++ b/src/app.php
@@ -17,7 +17,7 @@ $app['twig'] = $app->extend('twig', function ($twig, $app) {
     // add custom globals, filters, tags, ...
 
     $twig->addFunction(new \Twig_SimpleFunction('asset', function ($asset) use ($app) {
-        return $app['request_stack']->getMasterRequest()->getBasepath().'/'.$asset;
+        return $app['request_stack']->getMasterRequest()->getBasepath().'/'.ltrim($asset, '/');
     }));
 
     return $twig;


### PR DESCRIPTION
This prevents an url to be generated with two slashes when already given an absolute url.

FYI, that's also what's proposed in the doc: http://silex.sensiolabs.org/doc/cookbook/assets.html