### PR TITLE
Fixed create-project for stable 1.1.x version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.1.x-dev"
+            "dev-1.1": "1.1.x-dev"
         }
     }
 }


### PR DESCRIPTION
`composer create-project fabpot/silex-skeleton` was loading dev-master which is configured for silex ~2.0