### PR TITLE
added package http-kernel to fix the logger interface problem

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "symfony/security": "~2.3",
         "symfony/translation": "~2.3",
         "symfony/twig-bridge": "~2.3",
-        "symfony/validator": "~2.3"
+        "symfony/validator": "~2.3",
+        "symfony/http-kernel": "^2.8"
     },
     "autoload": {
         "psr-0": { "": "src/" }


### PR DESCRIPTION
fix the following exception after setting up:
```
ClassNotFoundException in Logger.php line 23:

Attempted to load interface "LoggerInterface" from namespace "Symfony\Component\HttpKernel\Log".
Did you forget a "use" statement for "Psr\Log\LoggerInterface"?
```