### PR TITLE
Allow to access to asset files on built-in server environment

### DIFF
--- a/web/index_dev.php
+++ b/web/index_dev.php
@@ -12,6 +12,10 @@ if (isset($_SERVER['HTTP_CLIENT_IP'])
     exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
 }
 
+if (preg_match('/\.(png|jpg|jpeg|gif|css|js|map|pdf|ico|ttf|woff|woff2)(\?.+)?$/', $_SERVER['REQUEST_URI'])) {
+    return false;
+}
+
 require_once __DIR__.'/../vendor/autoload.php';
 
 Debug::enable();


### PR DESCRIPTION
On built-in server environment, we cannot access to asset files because `web/index_dev.php` handles any requests including access to assets. This PR fix this problem.

refs. http://php.net/manual/en/features.commandline.webserver.php#example-433