### PR TITLE
Make dev mode default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "scripts": {
         "run": [
             "echo 'Started web server on http://localhost:8888'",
-            "php -S localhost:8888 -t web"
+            "php -S localhost:8888 -t web/index_dev.php"
         ]
     }
 }


### PR DESCRIPTION
Whats the point of including the dev toolbar if it doesn't run without some contrived command... make it default!

I even manually installed it, read the instructions and patched my controller with web profile code... that worked, but then I realized its also in the dev.php... a file that's not read by the default "composer run" command... perhaps maybe there should be a composer run-prod command as well. btw, running a docker image in a composer script works amazingly well... much better than trying to do the same in a node script.