### PR TITLE
Update code and Readme about included Providers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,13 @@ The Silex Skeleton is configured with the following service providers:
 
 * `MonologServiceProvider`_ - Enable logging in the development environment.
 
+* `HttpFragmentServiceProvider`_ - Provides support for the Symfony fragment
+  sub-framework, which allows you to embed fragments of HTML in a template.
+
+* `AssetServiceProvider`_ - Provides a way to manage URL generation and
+  versioning of web assets such as CSS stylesheets, JavaScript files and
+  image files.
+
 Read the `Providers`_ documentation for more details about Silex Service
 Providers.
 
@@ -74,4 +81,6 @@ Enjoy!
 .. _TwigServiceProvider: http://silex.sensiolabs.org/doc/master/providers/twig.html
 .. _WebProfilerServiceProvider: http://github.com/silexphp/Silex-WebProfiler
 .. _MonologServiceProvider: http://silex.sensiolabs.org/doc/master/providers/monolog.html
+.. _HttpFragmentServiceProvider: http://silex.sensiolabs.org/doc/master/providers/http_fragment.html
+.. _AssetServiceProvider: http://silex.sensiolabs.org/doc/master/providers/asset.html
 .. _Providers: http://silex.sensiolabs.org/doc/providers.html

--- a/src/app.php
+++ b/src/app.php
@@ -5,12 +5,14 @@ use Silex\Provider\AssetServiceProvider;
 use Silex\Provider\TwigServiceProvider;
 use Silex\Provider\ServiceControllerServiceProvider;
 use Silex\Provider\HttpFragmentServiceProvider;
+use Silex\Provider\ValidatorServiceProvider;
 
 $app = new Application();
 $app->register(new ServiceControllerServiceProvider());
 $app->register(new AssetServiceProvider());
 $app->register(new TwigServiceProvider());
 $app->register(new HttpFragmentServiceProvider());
+$app->register(new ValidatorServiceProvider());
 $app['twig'] = $app->extend('twig', function ($twig, $app) {
     // add custom globals, filters, tags, ...
 


### PR DESCRIPTION
From the initial README.rst the `ValidatorServiceProvider` was
missing, and there were already included providers like:
`HttpFragmentServiceProvider` and `AssetServiceProvider` which
where not specified in README.rst