### PR TITLE
fixed loading debug toolbar

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/process": "~2.8|3.0.*",
         "symfony/security": "~2.8|3.0.*",
         "symfony/translation": "~2.8|3.0.*",
-        "symfony/twig-bridge": "~2.8|3.0.*",
+        "symfony/twig-bridge": "~3.2",
         "symfony/validator": "~2.8|3.0.*"
     },
     "autoload": {


### PR DESCRIPTION
Fixes `"An error occurred while loading the web debug toolbar (500: Internal Server Error)."` by changing the `twig-bridge` version as suggested by @bastien-g (https://github.com/silexphp/Silex-Skeleton/issues/69#issuecomment-270605479).

Resolves #69 

Note: [committing the `composer.lock` file as the Composer documentation suggests](https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file) would also prevent others from not experiencing issues due to differences in dependency versions.