### PR TITLE
Update Readme about starting the PHP built-in web server.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,8 @@ command:
 .. code-block:: console
 
     $ cd path/to/install
-    $ COMPOSER_PROCESS_TIMEOUT=0 composer run
+    $ COMPOSER_PROCESS_TIMEOUT=0 composer run  OR
+    $ php -S localhost:8888 -t web
 
 Then, browse to http://localhost:8888/index_dev.php/
 


### PR DESCRIPTION
added another command to start the PHP built-in web server if the first option does not work.

